### PR TITLE
Implement CryptoStorage initialization and lookup

### DIFF
--- a/src/crypto_storage.cpp
+++ b/src/crypto_storage.cpp
@@ -22,4 +22,39 @@ void aes_decrypt(const uint8_t* encrypted, uint8_t* plain) {
     mbedtls_aes_free(&ctx);
 }
 
-// ... Rest wie bereits geliefert (init und checkUID)
+void CryptoStorage::init() {
+    if (!LittleFS.exists(uid_file)) {
+        File f = LittleFS.open(uid_file, "w");
+        if (f) {
+            f.close();
+        }
+    }
+}
+
+int CryptoStorage::checkUID(const String &uid) {
+    File f = LittleFS.open(uid_file, "r");
+    if (!f) {
+        return 0;
+    }
+
+    uint8_t encrypted[UID_ENTRY_SIZE];
+    uint8_t plain[UID_ENTRY_SIZE + 1];
+
+    while (f.read(encrypted, UID_ENTRY_SIZE) == UID_ENTRY_SIZE) {
+        aes_decrypt(encrypted, plain);
+        plain[UID_ENTRY_SIZE] = '\0';
+        String entry(reinterpret_cast<char*>(plain));
+        int sep = entry.indexOf(':');
+        if (sep > 0) {
+            String storedUid = entry.substring(0, sep);
+            int perm = entry.substring(sep + 1).toInt();
+            if (storedUid == uid) {
+                f.close();
+                return perm;
+            }
+        }
+    }
+
+    f.close();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add initialization for AES-encrypted UID storage
- decrypt and check UID entries in LittleFS

## Testing
- `pio run` (fails: HTTPClientError while installing platform)


------
https://chatgpt.com/codex/tasks/task_e_68c6c1a6022c833289caff0cb93f332b